### PR TITLE
Sepolicy Corrections :

### DIFF
--- a/common/private/gallery_app.te
+++ b/common/private/gallery_app.te
@@ -8,7 +8,6 @@ allow gallery_app app_api_service:service_manager find;
 allow gallery_app audioserver_service:service_manager find;
 allow gallery_app cameraserver_service:service_manager find;
 allow gallery_app drmserver_service:service_manager find;
-allow gallery_app mediacodec_service:service_manager find;
 allow gallery_app mediaextractor_service:service_manager find;
 allow gallery_app mediaserver_service:service_manager find;
 allow gallery_app mediametrics_service:service_manager find;

--- a/common/private/snap_app.te
+++ b/common/private/snap_app.te
@@ -8,7 +8,6 @@ allow snap_app app_api_service:service_manager find;
 allow snap_app audioserver_service:service_manager find;
 allow snap_app cameraserver_service:service_manager find;
 allow snap_app drmserver_service:service_manager find;
-allow snap_app mediacodec_service:service_manager find;
 allow snap_app mediaextractor_service:service_manager find;
 allow snap_app mediaserver_service:service_manager find;
 allow snap_app mediametrics_service:service_manager find;


### PR DESCRIPTION
	-device/corvus/sepolicy/common/private/gallery_app.te:11:ERROR 'unknown type mediacodec_service' at token ';' on line 60505:
	 allow gallery_app mediacodec_service:service_manager find;
	 allow gallery_app drmserver_service:service_manager find;
	 checkpolicy:  error(s) encountered while parsing configuration

	-device/corvus/sepolicy/common/private/snap_app.te:11:ERROR 'unknown type mediacodec_service' at token ';' on line 60779:
	 allow snap_app drmserver_service:service_manager find;
	 allow snap_app mediacodec_service:service_manager find;
	 checkpolicy:  error(s) encountered while parsing configuration